### PR TITLE
Fix and test undefined exports

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,13 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pkg:
-          - DiffEqProblemLibrary
-          - DAEProblemLibrary
-          - DDEProblemLibrary
-          - JumpProblemLibrary
-          - ODEProblemLibrary
-          - SDEProblemLibrary
+        project:
+          - '.'
+          - lib/DAEProblemLibrary
+          - lib/DDEProblemLibrary
+          - lib/JumpProblemLibrary
+          - lib/ODEProblemLibrary
+          - lib/SDEProblemLibrary
         version:
           - '1'
           - '1.6'
@@ -38,13 +38,13 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
         with:
-          project: "${{ matrix.pkg == 'DiffEqProblemLibrary' && '.' || format('lib/{0}', matrix.pkg) }}"
+          project: ${{ matrix.project }}
       - uses: julia-actions/julia-runtest@v1
         with:
-          project: "${{ matrix.pkg == 'DiffEqProblemLibrary' && '.' || format('lib/{0}', matrix.pkg) }}"
+          project: ${{ matrix.project }}
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: "${{ matrix.pkg == 'DiffEqProblemLibrary' && 'src' || format('lib/{0}/src', matrix.pkg) }}"
+          directories: ${{ matrix.project }}/src
       - uses: codecov/codecov-action@v3
         with:
           files: lcov.info

--- a/lib/DAEProblemLibrary/Project.toml
+++ b/lib/DAEProblemLibrary/Project.toml
@@ -7,5 +7,12 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
+Aqua = "0.5"
 DiffEqBase = "6"
 julia = "1.6"
+
+[extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+
+[targets]
+test = ["Aqua"]

--- a/lib/DAEProblemLibrary/test/runtests.jl
+++ b/lib/DAEProblemLibrary/test/runtests.jl
@@ -1,2 +1,8 @@
 # The test is simply that all of the examples build!
 using DAEProblemLibrary
+
+# Check that there are no undefined exports, stale dependencies, etc.
+# Ambiguity checks are disabled since tests fail due to ambiguities
+# in dependencies
+using Aqua
+Aqua.test_all(DAEProblemLibrary; ambiguities = false)

--- a/lib/DDEProblemLibrary/Project.toml
+++ b/lib/DDEProblemLibrary/Project.toml
@@ -1,10 +1,17 @@
 name = "DDEProblemLibrary"
 uuid = "f42792ee-6ffc-4e2a-ae83-8ee2f22de800"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 
 [compat]
+Aqua = "0.5"
 DiffEqBase = "6"
 julia = "1.6"
+
+[extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+
+[targets]
+test = ["Aqua"]

--- a/lib/DDEProblemLibrary/src/DDEProblemLibrary.jl
+++ b/lib/DDEProblemLibrary/src/DDEProblemLibrary.jl
@@ -6,11 +6,15 @@ using DiffEqBase
 # examples with constant delays
 export
 # DDEs with 1 constant delay
-      prob_dde_1delay_ip, prob_dde_1delay_oop, prob_dde_1delay_scalar,
-      prob_dde_1delay_long_ip, prob_dde_1delay_long_oop, prob_dde_1delay_long_scalar,
+      prob_dde_constant_1delay_ip, prob_dde_constant_1delay_oop,
+      prob_dde_constant_1delay_scalar,
+      prob_dde_constant_1delay_long_ip, prob_dde_constant_1delay_long_oop,
+      prob_dde_constant_1delay_long_scalar,
 # DDEs with 2 constant delays
-      prob_dde_2delays_ip, prob_dde_2delays_oop, prob_dde_2delays_scalar,
-      prob_dde_2delays_long_ip, prob_dde_2delays_long_oop, prob_dde_2delays_long_scalar
+      prob_dde_constant_2delays_ip, prob_dde_constant_2delays_oop,
+      prob_dde_constant_2delays_scalar,
+      prob_dde_constant_2delays_long_ip, prob_dde_constant_2delays_long_oop,
+      prob_dde_constant_2delays_long_scalar
 
 # DDETST problems
 export

--- a/lib/DDEProblemLibrary/test/runtests.jl
+++ b/lib/DDEProblemLibrary/test/runtests.jl
@@ -1,2 +1,8 @@
-# The test is simply that all of the examples build!
+# The main test is simply that all of the examples build!
 using DDEProblemLibrary
+
+# Check that there are no undefined exports, stale dependencies, etc.
+# Ambiguity checks are disabled since tests fail due to ambiguities
+# in dependencies
+using Aqua
+Aqua.test_all(DDEProblemLibrary; ambiguities = false)

--- a/lib/JumpProblemLibrary/Project.toml
+++ b/lib/JumpProblemLibrary/Project.toml
@@ -7,6 +7,13 @@ Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 
 [compat]
+Aqua = "0.5"
 Catalyst = "11, 12"
 DiffEqBase = "6"
 julia = "1.6"
+
+[extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+
+[targets]
+test = ["Aqua"]

--- a/lib/JumpProblemLibrary/test/runtests.jl
+++ b/lib/JumpProblemLibrary/test/runtests.jl
@@ -1,2 +1,8 @@
 # The test is simply that all of the examples build!
 using JumpProblemLibrary
+
+# Check that there are no undefined exports, stale dependencies, etc.
+# Ambiguity checks are disabled since tests fail due to ambiguities
+# in dependencies
+using Aqua
+Aqua.test_all(JumpProblemLibrary; ambiguities = false)

--- a/lib/ODEProblemLibrary/Project.toml
+++ b/lib/ODEProblemLibrary/Project.toml
@@ -12,8 +12,15 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+Aqua = "0.5"
 DiffEqBase = "6"
 DiffEqOperators = "4"
 Latexify = "0.15"
 ModelingToolkit = "7,8"
 julia = "1.6"
+
+[extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+
+[targets]
+test = ["Aqua"]

--- a/lib/ODEProblemLibrary/test/runtests.jl
+++ b/lib/ODEProblemLibrary/test/runtests.jl
@@ -1,2 +1,8 @@
 # The test is simply that all of the examples build!
 using ODEProblemLibrary
+
+# Check that there are no undefined exports, stale dependencies, etc.
+# Ambiguity checks are disabled since tests fail due to ambiguities
+# in dependencies
+using Aqua
+Aqua.test_all(ODEProblemLibrary; ambiguities = false)

--- a/lib/SDEProblemLibrary/Project.toml
+++ b/lib/SDEProblemLibrary/Project.toml
@@ -8,6 +8,13 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
+Aqua = "0.5"
 Catalyst = "11, 12"
 DiffEqBase = "6"
 julia = "1.6"
+
+[extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+
+[targets]
+test = ["Aqua"]

--- a/lib/SDEProblemLibrary/test/runtests.jl
+++ b/lib/SDEProblemLibrary/test/runtests.jl
@@ -1,2 +1,8 @@
 # The test is simply that all of the examples build!
 using SDEProblemLibrary
+
+# Check that there are no undefined exports, stale dependencies, etc.
+# Ambiguity checks are disabled since tests fail due to ambiguities
+# in dependencies
+using Aqua
+Aqua.test_all(SDEProblemLibrary; ambiguities = false)


### PR DESCRIPTION
When I removed the deprecations in DDEProblemLibrary, I did not notice that the exports were outdated and some of them are undefined. I added tests for this, also to other packages.