### PR TITLE
Fix bug in `prob_dde_constant_2delays_oop`

### DIFF
--- a/lib/DDEProblemLibrary/Project.toml
+++ b/lib/DDEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "DDEProblemLibrary"
 uuid = "f42792ee-6ffc-4e2a-ae83-8ee2f22de800"
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/DDEProblemLibrary/src/constant_delays.jl
+++ b/lib/DDEProblemLibrary/src/constant_delays.jl
@@ -315,7 +315,7 @@ prob_dde_constant_2delays_oop
 
 function f_dde_constant_2delays_oop(u, h, p, t)
     T = typeof(t)
-    (h(p, t - T(1 / 3)) .+ h(p, t - T(1 / 5))) ./ oneunit(t)
+    (h(p, t - T(1 / 3)) .+ h(p, t - T(1 / 5))) ./ (-oneunit(t))
 end
 
 const prob_dde_constant_2delays_oop = DDEProblem(DDEFunction(f_dde_constant_2delays_oop;
@@ -366,7 +366,6 @@ prob_dde_constant_2delays_long_ip
 function f_dde_constant_2delays_long_ip!(du, u, h, p, t)
     T = typeof(t)
     du[1] = -(h(p, t - T(1 / 3); idxs = 1) + h(p, t - T(1 / 5); idxs = 1)) / oneunit(t)
-
     nothing
 end
 


### PR DESCRIPTION
Seems I managed to introduce a bug... This should fix the test failures in https://github.com/SciML/DelayDiffEq.jl/pull/240.