### PR TITLE
Correct spelling of Lotka-Volterra

### DIFF
--- a/lib/ODEProblemLibrary/src/ODEProblemLibrary.jl
+++ b/lib/ODEProblemLibrary/src/ODEProblemLibrary.jl
@@ -20,6 +20,7 @@ Random.seed!(100)
 export prob_ode_linear, prob_ode_bigfloatlinear, prob_ode_2Dlinear,
        prob_ode_large2Dlinear, prob_ode_bigfloat2Dlinear, prob_ode_rigidbody,
        prob_ode_2Dlinear_notinplace, prob_ode_vanderpol, prob_ode_vanderpol_stiff,
+       prob_ode_lotkavolterra, prob_ode_fitzhughnagumo,
        prob_ode_rober, prob_ode_threebody, prob_ode_mm_linear, prob_ode_pleiades,
        prob_ode_brusselator_1d, prob_ode_brusselator_2d, prob_ode_orego,
        prob_ode_hires, prob_ode_pollution, prob_ode_filament,

--- a/lib/ODEProblemLibrary/src/ode_simple_nonlinear_prob.jl
+++ b/lib/ODEProblemLibrary/src/ode_simple_nonlinear_prob.jl
@@ -8,7 +8,7 @@ function lotka(du, u, p, t)
 end
 
 """
-Lotka-Voltera Equations (Non-stiff)
+Lotka-Volterra Equations (Non-stiff)
 
 ```math
 \\frac{dx}{dt} = ax - bxy
@@ -19,7 +19,7 @@ Lotka-Voltera Equations (Non-stiff)
 
 with initial condition ``x=y=1``
 """
-prob_ode_lotkavoltera = ODEProblem(lotka, [1.0, 1.0], (0.0, 1.0), [1.5, 1.0, 3.0, 1.0])
+prob_ode_lotkavolterra = ODEProblem(lotka, [1.0, 1.0], (0.0, 1.0), [1.5, 1.0, 3.0, 1.0])
 
 ## Fitzhugh-Nagumo
 


### PR DESCRIPTION
Fixes #96

I also added `prob_ode_lotkavolterra` and `prob_ode_fitzhughnagumo` to the exports, since it seemed a bit arbitrary that those two are not exported but most (all?) others are. Let me know if I should revert this. 

Also: **Should I increase the version of ODEProblemLibrary as part of this PR, or is that handled separately?**

Thanks! 