### PR TITLE
Fix 13th and 17th BVP test problems

### DIFF
--- a/lib/BVProblemLibrary/Project.toml
+++ b/lib/BVProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "BVProblemLibrary"
 uuid = "ded0fc24-dfea-4565-b1d9-79c027d14d84"
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/BVProblemLibrary/src/linear.jl
+++ b/lib/BVProblemLibrary/src/linear.jl
@@ -783,7 +783,7 @@ function prob_bvp_linear_13_bca!(res_a, u_a, p)
     res_a[1] = u_a[1]
 end
 function prob_bvp_linear_13_bcb!(res_b, u_b, p)
-    res_b[1] = u_b[1] + 1
+    res_b[1] = u_b[1] + 1 - exp(-2 / sqrt(p))
 end
 prob_bvp_linear_13_function = BVPFunction(
     prob_bvp_linear_13_f!, (prob_bvp_linear_13_bca!, prob_bvp_linear_13_bcb!),
@@ -1019,7 +1019,7 @@ prob_bvp_linear_16 = BVProblem(prob_bvp_linear_16_function,
 ################### linear_bvp17 ############################
 function prob_bvp_linear_17_analytic(u, λ, t)
     [t / sqrt(λ + t^2),
-        (λ - t^2) / (λ + t^2)^2]
+        1 / sqrt(λ + t^2) - t^2 / (λ + t^2)^(3 / 2)]
 end
 function prob_bvp_linear_17_f!(du, u, p, t)
     du[1] = u[2]


### PR DESCRIPTION
Fix 13th and 17th linear BVP test problems.

Error in 13th: The boundary condition on $u(1)$ should be $\exp(-2/\sqrt{\lambda})$

Error in 17th: The derivative of analytical solution should be $z'(t)=1/\sqrt{λ + t^2} - t^2 / (λ + t^2)^{(3 / 2)}$

Related to https://github.com/SciML/SimpleBoundaryValueDiffEq.jl/pull/4