### PR TITLE
stop supporting MTK@9

### DIFF
--- a/lib/ODEProblemLibrary/Project.toml
+++ b/lib/ODEProblemLibrary/Project.toml
@@ -15,7 +15,7 @@ RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 Aqua = "0.5"
 DiffEqBase = "6"
 Latexify = "0.16"
-ModelingToolkit = "9, 10"
+ModelingToolkit = "10"
 RuntimeGeneratedFunctions = "0.5"
 julia = "1.10"
 


### PR DESCRIPTION
MTK v9 and v10 are not mutually usable, so if we support MTK v10, we aren't supporting MTK v9 anymore.

I still think that MTK v10 support should be a major verison bump here, but oh well.