### PR TITLE
Fix backslash in TeX in BVProblemLibrary.jl

### DIFF
--- a/lib/BVProblemLibrary/src/BVProblemLibrary.jl
+++ b/lib/BVProblemLibrary/src/BVProblemLibrary.jl
@@ -143,7 +143,7 @@ Given by
 \frac{dz_3}{dt}=acc\frac{1}{|V_c|\sqrt{1+z_6^2}}
 ```
 ```math
-\frac{dz_4}{dt}=acc\frac{1}{|V_c|\sqrt{1+z_6^2}}-frac{g}{V_c}
+\frac{dz_4}{dt}=acc\frac{1}{|V_c|\sqrt{1+z_6^2}}-\frac{g}{V_c}
 ```
 ```math
 \frac{dz_5}{dt}=0


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
  None applicable
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fix `frac` to `\frac`
