### PR TITLE
Use `@doc_str` macro for docstrings

### DIFF
--- a/lib/ODEProblemLibrary/src/brusselator_prob.jl
+++ b/lib/ODEProblemLibrary/src/brusselator_prob.jl
@@ -55,27 +55,32 @@ function init_brusselator_2d(xyd)
 end
 xyd_brusselator = range(0, stop = 1, length = 32)
 
-"""
+@doc doc"""
 2D Brusselator
 
 ```math
-\\frac{\\partial u}{\\partial t} = 1 + u^2v - 4.4u + \\alpha(\\frac{\\partial^2 u}{\\partial x^2} + \\frac{\\partial^2 u}{\\partial y^2}) + f(x, y, t)
+\frac{\partial u}{\partial t} = 1 + u^2v - 4.4u + \alpha(\frac{\partial^2 u}{\partial x^2} + \frac{\partial^2 u}{\partial y^2}) + f(x, y, t)
 ```
 ```math
-\\frac{\\partial v}{\\partial t} = 3.4u - u^2v + \\alpha(\\frac{\\partial^2 u}{\\partial x^2} + \\frac{\\partial^2 u}{\\partial y^2})
+\frac{\partial v}{\partial t} = 3.4u - u^2v + \alpha(\frac{\partial^2 u}{\partial x^2} + \frac{\partial^2 u}{\partial y^2})
 ```
 
 where
 
-``f(x, y, t) = \\begin{cases} 5 & \\quad \\text{if } (x-0.3)^2+(y-0.6)^2 ≤ 0.1^2 \\text{ and } t ≥ 1.1 \\\\ 0 & \\quad \\text{else} \\end{cases}``
+```math
+f(x, y, t) = \begin{cases}
+    5 & \text{if } (x-0.3)^2+(y-0.6)^2 ≤ 0.1^2 \text{ and } t ≥ 1.1 \\
+    0 & \text{else}
+\end{cases}
+```
 
 and the initial conditions are
 
 ```math
-u(x, y, 0) = 22\\cdot y(1-y)^{3/2}
+u(x, y, 0) = 22\cdot y(1-y)^{3/2}
 ```
 ```math
-v(x, y, 0) = 27\\cdot x(1-x)^{3/2}
+v(x, y, 0) = 27\cdot x(1-x)^{3/2}
 ```
 
 with the periodic boundary condition
@@ -121,20 +126,20 @@ function init_brusselator_1d(N)
     u
 end
 
-"""
+@doc doc"""
 1D Brusselator
 
 ```math
-\\frac{\\partial u}{\\partial t} = A + u^2v - (B+1)u + \\alpha\\frac{\\partial^2 u}{\\partial x^2}
+\frac{\partial u}{\partial t} = A + u^2v - (B+1)u + \alpha\frac{\partial^2 u}{\partial x^2}
 ```
 ```math
-\\frac{\\partial v}{\\partial t} = Bu - u^2v + \\alpha\\frac{\\partial^2 u}{\\partial x^2}
+\frac{\partial v}{\partial t} = Bu - u^2v + \alpha\frac{\partial^2 u}{\partial x^2}
 ```
 
 and the initial conditions are
 
 ```math
-u(x,0) = 1+\\sin(2π x)
+u(x,0) = 1+\sin(2π x)
 ```
 ```math
 v(x,0) = 3

--- a/lib/ODEProblemLibrary/src/ode_simple_nonlinear_prob.jl
+++ b/lib/ODEProblemLibrary/src/ode_simple_nonlinear_prob.jl
@@ -7,14 +7,14 @@ function lotka(du, u, p, t)
     du[2] = -p[3] * y + p[4] * x * y
 end
 
-"""
+@doc doc"""
 Lotka-Volterra Equations (Non-stiff)
 
 ```math
-\\frac{dx}{dt} = ax - bxy
+\frac{dx}{dt} = ax - bxy
 ```
 ```math
-\\frac{dy}{dt} = -cy + dxy
+\frac{dy}{dt} = -cy + dxy
 ```
 
 with initial condition ``x=y=1``
@@ -33,14 +33,14 @@ function fitz(du, u, p, t)
     du[1] = v - v^3 / 3 - w + l
     du[2] = τinv * (v + a - b * w)
 end
-"""
+@doc doc"""
 Fitzhugh-Nagumo (Non-stiff)
 
 ```math
-\\frac{dv}{dt} = v - \\frac{v^3}{3} - w + I_{est}
+\frac{dv}{dt} = v - \frac{v^3}{3} - w + I_{est}
 ```
 ```math
-τ \\frac{dw}{dt} = v + a -bw
+τ \frac{dw}{dt} = v + a -bw
 ```
 
 with initial condition ``v=w=1``
@@ -68,34 +68,34 @@ function vanderpol_jac(J, u, p, t)
     J[2,2] = μ * (1 - x^2)
 end
 
-"""
+@doc doc"""
 Van der Pol Equations
 
 ```math
-\\frac{dx}{dt} = y
+\frac{dx}{dt} = y
 ```
 ```math
-\\frac{dy}{dt} = μ((1-x^2)y -x)
+\frac{dy}{dt} = μ ((1-x^2)y - x)
 ```
 
-with ``μ=1.0`` and ``u_0=[\\sqrt{3}, 0]`` (where ``u[1] = x``, ``u[2] = y``)
+with ``μ=1.0`` and ``u_0=[\sqrt{3}, 0]`` (where ``u[1] = x``, ``u[2] = y``)
 
 Non-stiff parameters.
 """
-prob_ode_vanderpol = ODEProblem(ODEFunction(vanderpol, jac=vanderpol_jac), 
+prob_ode_vanderpol = ODEProblem(ODEFunction(vanderpol, jac=vanderpol_jac),
     [sqrt(3), 0.0], (0.0, 1.0), [1.0])
 
-"""
+@doc doc"""
 Van der Pol Equations
 
 ```math
-\\frac{dx}{dt} = y
+\frac{dx}{dt} = y
 ```
 ```math
-\\frac{dy}{dt} = μ((1-x^2)y -x)
+\frac{dy}{dt} = μ ((1-x^2)y - x)
 ```
 
-with ``μ=10^6`` and ``u_0=[\\sqrt{3}, 0]`` (where ``u[1] = x``, ``u[2] = y``)
+with ``μ=10^6`` and ``u_0=[\sqrt{3}, 0]`` (where ``u[1] = x``, ``u[2] = y``)
 
 Stiff parameters.
 """
@@ -115,20 +115,20 @@ function rober(du, u, p, t)
     du[3] = k₂ * y₂^2
 end
 
-"""
+@doc doc"""
 The Robertson biochemical reactions: (Stiff)
 
 ```math
-\\frac{dy₁}{dt} = -k₁y₁+k₃y₂y₃
+\frac{dy₁}{dt} = -k₁y₁+k₃y₂y₃
 ```
 ```math
-\\frac{dy₂}{dt} =  k₁y₁-k₂y₂^2-k₃y₂y₃
+\frac{dy₂}{dt} =  k₁y₁-k₂y₂^2-k₃y₂y₃
 ```
 ```math
-\\frac{dy₃}{dt} =  k₂y₂^2
+\frac{dy₃}{dt} =  k₂y₂^2
 ```
 
-where ``k₁=0.04``, ``k₂=3\\times10^7``, ``k₃=10^4``. For details, see:
+where ``k₁=0.04``, ``k₂=3\times10^7``, ``k₃=10^4``. For details, see:
 
 Hairer Norsett Wanner Solving Ordinary Differential Equations I - Nonstiff Problems Page 129
 
@@ -202,17 +202,17 @@ function rigidbody(du, u, p, t)
     du[3] = I₃ * y₁ * y₂
 end
 
-"""
+@doc doc"""
 Rigid Body Equations (Non-stiff)
 
 ```math
-\\frac{dy₁}{dt}  = I₁y₂y₃
+\frac{dy₁}{dt}  = I₁y₂y₃
 ```
 ```math
-\\frac{dy₂}{dt}  = I₂y₁y₃
+\frac{dy₂}{dt}  = I₂y₁y₃
 ```
 ```math
-\\frac{dy₃}{dt}  = I₃y₁y₂
+\frac{dy₃}{dt}  = I₃y₁y₂
 ```
 
 with ``I₁=-2``, ``I₂=1.25``, and ``I₃=-1/2``.
@@ -240,7 +240,6 @@ pleiades = (du, u, p, t) -> begin
         du[i] = zero(eltype(u))
     end
     for i in 1:7, j in 1:7
-
         if i != j
             r = ((x[i] - x[j])^2 + (y[i] - y[j])^2)^(3 / 2)
             du[14 + i] += j * (x[j] - x[i]) / r
@@ -376,7 +375,7 @@ prob_ode_mm_linear = ODEProblem(mm_f, rand(4), (0.0, 1.0))
 function hires(du, u, p, t)
     y1, y2, y3, y4, y5, y6, y7, y8 = u
     p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12 = p
-    
+
     du[1] = -p1 * y1 + p2 * y2 + p3 * y3 + p4
     du[2] = p1 * y1 - p5 * y2
     du[3] = -p6 * y3 + p2 * y4 + p7 * y5
@@ -393,24 +392,24 @@ u0[8] = 0.0057
 
 p = (1.71, 0.43, 8.32, 0.0007, 8.75, 10.03, 0.035, 1.12, 1.745, 280.0, 0.69, 1.81)
 
-"""
+@doc doc"""
 Hires Problem (Stiff)
 
 It is in the form of
 
 ```math
-\\frac{dy}{dt} = f(y)
+\frac{dy}{dt} = f(y)
 ```
 
  with
 
 ```math
- y(0)=y_0, \\quad y \\in ℝ^8, \\quad 0 ≤ t ≤ 321.8122
+ y(0)=y_0, \quad y \in ℝ^8, \quad 0 ≤ t ≤ 321.8122
 ```
 
 where ``f`` is defined by
 
-``f(y) = \\begin{pmatrix} −1.71y_1 & +0.43y_2 & +8.32y_3 & +0.0007y_4 & \\\\ 1.71y_1 & −8.75y_2 & & & \\\\ −10.03y_3 & +0.43y_4 & +0.035y_5 & & \\\\ 8.32y_2 & +1.71y_3 & −1.12y_4 & & \\\\ −1.745y_5 & +0.43y_6 & +0.43y_7 & & \\\\ −280y_6y_8 & +0.69y_4 & +1.71y_5 & −0.43y_6 & +0.69y_7 \\\\ 280y_6y_8 & −1.81y_7 & & & \\\\ −280y_6y_8 & +1.81y_7 & & & \\end{pmatrix}``
+``f(y) = \begin{pmatrix} −1.71y_1 & +0.43y_2 & +8.32y_3 & +0.0007y_4 & \\ 1.71y_1 & −8.75y_2 & & & \\ −10.03y_3 & +0.43y_4 & +0.035y_5 & & \\ 8.32y_2 & +1.71y_3 & −1.12y_4 & & \\ −1.745y_5 & +0.43y_6 & +0.43y_7 & & \\ −280y_6y_8 & +0.69y_4 & +1.71y_5 & −0.43y_6 & +0.69y_7 \\ 280y_6y_8 & −1.81y_7 & & & \\ −280y_6y_8 & +1.81y_7 & & & \end{pmatrix}``
 
 Reference: [demohires.pdf](http://www.radford.edu/~thompson/vodef90web/problems/demosnodislin/Demos_Pitagora/DemoHires/demohires.pdf)
 Notebook: [Hires.ipynb](http://nbviewer.jupyter.org/github/JuliaDiffEq/DiffEqBenchmarks.jl/blob/master/StiffODE/Hires.ipynb)
@@ -422,24 +421,24 @@ prob_ode_hires = ODEProblem(hires, u0, (0.0, 321.8122), p)
 function orego(du, u, p, t)
     y1, y2, y3 = u
     p1, p2, p3 = p
-    
+
     du[1] = p1 * (y2 + y1 * (1 - p2 * y1 - y2))
     du[2] = (y3 - (1 + y1) * y2) / p1
     du[3] = p3 * (y1 - y3)
 end
 
-"""
+@doc doc"""
 Orego Problem (Stiff)
 
-It is in the form of ``\\frac{dy}{dt}=f(y), \\quad y(0)=y0,`` with
+It is in the form of ``\frac{dy}{dt}=f(y), \quad y(0)=y_0,`` with
 
 ```math
-y \\in ℝ^3, \\quad 0 ≤ t ≤ 360
+y \in ℝ^3, \quad 0 ≤ t ≤ 360
 ```
 
 where ``f`` is defined by
 
-``f(y) = \\begin{pmatrix} s(y_2 - y_1(1-qy_1-y_2)) \\\\ (y_3 - y_2(1+y_1))/s \\\\ w(y_1-y_3) \\end{pmatrix}``
+``f(y) = \begin{pmatrix} s(y_2 - y_1(1-qy_1-y_2)) \\ (y_3 - y_2(1+y_1))/s \\ w(y_1-y_3) \end{pmatrix}``
 
 where ``s=77.27``, ``w=0.161`` and ``q=8.375⋅10^{-6}``.
 

--- a/lib/ODEProblemLibrary/src/pollution_prob.jl
+++ b/lib/ODEProblemLibrary/src/pollution_prob.jl
@@ -188,24 +188,24 @@ u0[8] = 0.3
 u0[9] = 0.01
 u0[17] = 0.007
 
-"""
+@doc doc"""
 Pollution Problem (Stiff)
 
-This IVP is a stiff system of 20 non-linear Ordinary Differential Equations. It is in the form of 
+This IVP is a stiff system of 20 non-linear Ordinary Differential Equations. It is in the form of
 
 ```math
-\\frac{dy}{dt}=f(y)
+\frac{dy}{dt}=f(y)
 ```
 
 with
 
 ```math
-y(0)=y0, \\quad y \\in ℝ^20, \\quad 0 ≤ t ≤ 60
+y(0)=y_0, \quad y \in ℝ^{20}, \quad 0 ≤ t ≤ 60
 ```
 
 where ``f`` is defined by
 
-``f(y) = \\begin{pmatrix} -\\sum_{j∈{1,10,14,23,24}} r_j + \\sum_{j∈{2,3,9,11,12,22,25}} r_j \\\\ -r_2 - r_3 - r_9 - r_12 + r_1 + r_{21} \\\\ -r_{15} + r_1 + r_{17} + r_{19} + r_{22} \\\\ -r_2 - r_{16} - r_{17} - r_{23} + r_{15} \\\\ -r_3 + 2r_4 + r_6 + r_7 + r_{13} + r_{20} \\\\ -r_6 - r_8 - r_{14} - r_{20} + r_3 + 2r_{18} \\\\ -r_4 - r_5 - r_6 + r_{13} \\\\ r_4 + r_5 + r_6 + r_7 \\\\ -r_7 - r_8 \\\\ -r_{12} + r_7 + r_9 \\\\ -r_9 - r_{10} + r_8 + r_{11} \\\\ r_9 \\\\ -r_{11} + r_{10} \\\\ -r_{13} + r_{12} \\\\ r_{14} \\\\ -r_{18} - r_{19} + r_{16} \\\\ -r_{20} \\\\ r_{20} \\\\ -r{21} - r_{22} - r_{24} + r_{23} + r_{25} \\\\ -r_{25} + r_{24} \\end{pmatrix}``
+``f(y) = \begin{pmatrix} -\sum_{j∈{1,10,14,23,24}} r_j + \sum_{j∈{2,3,9,11,12,22,25}} r_j \\ -r_2 - r_3 - r_9 - r_12 + r_1 + r_{21} \\ -r_{15} + r_1 + r_{17} + r_{19} + r_{22} \\ -r_2 - r_{16} - r_{17} - r_{23} + r_{15} \\ -r_3 + 2r_4 + r_6 + r_7 + r_{13} + r_{20} \\ -r_6 - r_8 - r_{14} - r_{20} + r_3 + 2r_{18} \\ -r_4 - r_5 - r_6 + r_{13} \\ r_4 + r_5 + r_6 + r_7 \\ -r_7 - r_8 \\ -r_{12} + r_7 + r_9 \\ -r_9 - r_{10} + r_8 + r_{11} \\ r_9 \\ -r_{11} + r_{10} \\ -r_{13} + r_{12} \\ r_{14} \\ -r_{18} - r_{19} + r_{16} \\ -r_{20} \\ r_{20} \\ -r{21} - r_{22} - r_{24} + r_{23} + r_{25} \\ -r_{25} + r_{24} \end{pmatrix}``
 
 with the initial condition of
 

--- a/lib/ODEProblemLibrary/src/strange_attractors.jl
+++ b/lib/ODEProblemLibrary/src/strange_attractors.jl
@@ -12,15 +12,15 @@ function thomas_eqs(du, u, p, t)
     du[3] = sin(x) - b * z
 end
 
-"""
+@doc doc"""
 Thomas' cyclically symmetric attractor equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= \\sin(y) - bx \\\\
-\\frac{dy}{dt} &= \\sin(z) - by \\\\
-\\frac{dz}{dt} &= \\sin(x) - bz
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= \sin(y) - bx \\
+\frac{dy}{dt} &= \sin(z) - by \\
+\frac{dz}{dt} &= \sin(x) - bz
+\end{align}
 ```
 
 with parameter ``b = 0.208186`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``
@@ -42,15 +42,15 @@ function lorenz_eqs(du, u, p, t)
     du[3] = x * y - β * z
 end
 
-"""
+@doc doc"""
 Lorenz equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= σ(y - x) \\\\
-\\frac{dy}{dt} &= x(ρ - z) - y \\\\
-\\frac{dz}{dt} &= xy - βz
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= σ(y - x) \\
+\frac{dy}{dt} &= x(ρ - z) - y \\
+\frac{dz}{dt} &= xy - βz
+\end{align}
 ```
 
 with parameters ``σ=10, ρ=28, β=8/3`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``
@@ -72,15 +72,15 @@ function aizawa_eqs(du, u, p, t)
     du[3] = c + a * z - z^3 / 3 - (x^2 + y^2) * (1 + e * z) + f * z * x^3
 end
 
-"""
+@doc doc"""
 Aizawa equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= (z - b)x - dy \\\\
-\\frac{dy}{dt} &= dx + (z - b)y \\\\
-\\frac{dz}{dt} &= c + az - \\frac{z^3}{3} - (x^2 + y^2)(1 + ez) + fzx^3
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= (z - b)x - dy \\
+\frac{dy}{dt} &= dx + (z - b)y \\
+\frac{dz}{dt} &= c + az - \frac{z^3}{3} - (x^2 + y^2)(1 + ez) + fzx^3
+\end{align}
 ```
 
 with parameters ``a=0.95, b=0.7, c=0.6, d=3.5, e=0.25, f=0.1`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``
@@ -100,15 +100,15 @@ function dadras_eqs(du, u, p, t)
     du[3] = d * x * y - e * z
 end
 
-"""
+@doc doc"""
 Dadras equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= y - ax + byz \\\\
-\\frac{dy}{dt} &= cy - xz + z \\\\
-\\frac{dz}{dt} &= dxy - ez
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= y - ax + byz \\
+\frac{dy}{dt} &= cy - xz + z \\
+\frac{dz}{dt} &= dxy - ez
+\end{align}
 ```
 
 with parameters ``a=3, b=2.7, c=1.7, d=2, e=9`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``
@@ -128,15 +128,15 @@ function chen_eqs(du, u, p, t)
     du[3] = x * y - b * z
 end
 
-"""
+@doc doc"""
 Chen equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= a(y - x) \\\\
-\\frac{dy}{dt} &= (c - a)x - xz + cy \\\\
-\\frac{dz}{dt} &= xy - bz
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= a(y - x) \\
+\frac{dy}{dt} &= (c - a)x - xz + cy \\
+\frac{dz}{dt} &= xy - bz
+\end{align}
 ```
 
 with parameters ``a=35, b=3, c=28`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``
@@ -156,15 +156,15 @@ function rossler_eqs(du, u, p, t)
     du[3] = b + z * (x - c)
 end
 
-"""
+@doc doc"""
 Rössler equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= -(y + z) \\\\
-\\frac{dy}{dt} &= x + ay \\\\
-\\frac{dz}{dt} &= b + z(x - c)
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= -(y + z) \\
+\frac{dy}{dt} &= x + ay \\
+\frac{dz}{dt} &= b + z(x - c)
+\end{align}
 ```
 
 with parameters ``a=0.2, b=0.2, c=5.7`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``
@@ -185,15 +185,15 @@ function rabinovich_fabrikant_eqs(du, u, p, t)
     du[3] = -2 * z * (a + x * y)
 end
 
-"""
+@doc doc"""
 Rabinovich-Fabrikant equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= y(z - 1 + x^2) + bx \\\\
-\\frac{dy}{dt} &= x(3z + 1 - x^2) + by \\\\
-\\frac{dz}{dt} &= -2z(a + xy)
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= y(z - 1 + x^2) + bx \\
+\frac{dy}{dt} &= x(3z + 1 - x^2) + by \\
+\frac{dz}{dt} &= -2z(a + xy)
+\end{align}
 ```
 
 with parameters ``a=0.14, b=0.10`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``
@@ -213,15 +213,15 @@ function sprott_eqs(du, u, p, t)
     du[3] = x - x^2 - y^2
 end
 
-"""
+@doc doc"""
 Sprott equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= y + axy + xz \\\\
-\\frac{dy}{dt} &= 1 - bx^2 + yz \\\\
-\\frac{dz}{dt} &= x - x^2 - y^2
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= y + axy + xz \\
+\frac{dy}{dt} &= 1 - bx^2 + yz \\
+\frac{dz}{dt} &= x - x^2 - y^2
+\end{align}
 ```
 
 with parameters ``a=2.07, b=1.79`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``
@@ -241,15 +241,15 @@ function hindmarsh_rose_eqs(du, u, p, t)
     du[3] = r * (s * (x - xr) - z)
 end
 
-"""
+@doc doc"""
 Hindmarsh-Rose equations
 
 ```math
-\\begin{align}
-\\frac{dx}{dt} &= y - ax^3 + bx^2 - z + i \\\\
-\\frac{dy}{dt} &= c - dx^2 - y \\\\
-\\frac{dz}{dt} &= r(s(x - x_r) - z)
-\\end{align}
+\begin{align}
+\frac{dx}{dt} &= y - ax^3 + bx^2 - z + i \\
+\frac{dy}{dt} &= c - dx^2 - y \\
+\frac{dz}{dt} &= r(s(x - x_r) - z)
+\end{align}
 ```
 
 with parameters ``a=1, b=3, c=1, d=5, r=1e-2, s=4, x_r=-8/5, i=5`` and initial conditions ``x(0)=1, y(0)=0, z(0)=0``


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The docstrings are TeX-heavy, and this allows easier writing of backslashes.
