### PR TITLE
compat: raise SciMLTesting floor to 2.10

### DIFF
--- a/lib/BVProblemLibrary/Project.toml
+++ b/lib/BVProblemLibrary/Project.toml
@@ -12,7 +12,7 @@ Pkg = "1.10"
 SafeTestsets = "0.1"
 SpecialFunctions = "2.3"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/BVProblemLibrary/Project.toml
+++ b/lib/BVProblemLibrary/Project.toml
@@ -12,9 +12,11 @@ Pkg = "1.10"
 SafeTestsets = "0.1"
 SpecialFunctions = "2.3"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/DAEProblemLibrary/Project.toml
+++ b/lib/DAEProblemLibrary/Project.toml
@@ -10,9 +10,11 @@ DiffEqBase = "7"
 Pkg = "1.10"
 SafeTestsets = "0.1"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/DAEProblemLibrary/Project.toml
+++ b/lib/DAEProblemLibrary/Project.toml
@@ -10,7 +10,7 @@ DiffEqBase = "7"
 Pkg = "1.10"
 SafeTestsets = "0.1"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/DDEProblemLibrary/Project.toml
+++ b/lib/DDEProblemLibrary/Project.toml
@@ -10,9 +10,11 @@ DiffEqBase = "7"
 Pkg = "1.10"
 SafeTestsets = "0.1"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/DDEProblemLibrary/Project.toml
+++ b/lib/DDEProblemLibrary/Project.toml
@@ -10,7 +10,7 @@ DiffEqBase = "7"
 Pkg = "1.10"
 SafeTestsets = "0.1"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/JumpProblemLibrary/Project.toml
+++ b/lib/JumpProblemLibrary/Project.toml
@@ -12,7 +12,7 @@ Pkg = "1.10"
 RuntimeGeneratedFunctions = "0.5"
 SafeTestsets = "0.1"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/JumpProblemLibrary/Project.toml
+++ b/lib/JumpProblemLibrary/Project.toml
@@ -12,9 +12,11 @@ Pkg = "1.10"
 RuntimeGeneratedFunctions = "0.5"
 SafeTestsets = "0.1"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/NonlinearProblemLibrary/Project.toml
+++ b/lib/NonlinearProblemLibrary/Project.toml
@@ -12,7 +12,7 @@ Pkg = "1.10"
 SafeTestsets = "0.1"
 SciMLBase = "3"
 Test = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/NonlinearProblemLibrary/Project.toml
+++ b/lib/NonlinearProblemLibrary/Project.toml
@@ -12,9 +12,11 @@ Pkg = "1.10"
 SafeTestsets = "0.1"
 SciMLBase = "3"
 Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/ODEProblemLibrary/Project.toml
+++ b/lib/ODEProblemLibrary/Project.toml
@@ -14,9 +14,11 @@ Pkg = "1.10"
 Random = "1.10"
 SafeTestsets = "0.1"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/ODEProblemLibrary/Project.toml
+++ b/lib/ODEProblemLibrary/Project.toml
@@ -14,7 +14,7 @@ Pkg = "1.10"
 Random = "1.10"
 SafeTestsets = "0.1"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/SDEProblemLibrary/Project.toml
+++ b/lib/SDEProblemLibrary/Project.toml
@@ -14,7 +14,7 @@ RuntimeGeneratedFunctions = "0.5"
 SafeTestsets = "0.1"
 SciMLBase = "3"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/SDEProblemLibrary/Project.toml
+++ b/lib/SDEProblemLibrary/Project.toml
@@ -14,9 +14,11 @@ RuntimeGeneratedFunctions = "0.5"
 SafeTestsets = "0.1"
 SciMLBase = "3"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This is a mechanical compat-only PR. Raise every affected root/sublibrary SciMLTesting compat entry from 2.1 to 2.10 so the repository uses the strict SciMLTesting QA defaults. No source, test behavior, or documentation changes are included. Please ignore this draft until reviewed by @ChrisRackauckas. Local git diff --check and typos checks pass.