### PR TITLE
Require Symbolics 7.39.2 for JumpProblemLibrary 32-bit CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,15 @@ ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
 
+[sources]
+BVProblemLibrary = {path = "lib/BVProblemLibrary"}
+DAEProblemLibrary = {path = "lib/DAEProblemLibrary"}
+DDEProblemLibrary = {path = "lib/DDEProblemLibrary"}
+JumpProblemLibrary = {path = "lib/JumpProblemLibrary"}
+NonlinearProblemLibrary = {path = "lib/NonlinearProblemLibrary"}
+ODEProblemLibrary = {path = "lib/ODEProblemLibrary"}
+SDEProblemLibrary = {path = "lib/SDEProblemLibrary"}
+
 [compat]
 BVProblemLibrary = "0.1"
 DAEProblemLibrary = "0.1"

--- a/lib/JumpProblemLibrary/Project.toml
+++ b/lib/JumpProblemLibrary/Project.toml
@@ -5,12 +5,16 @@ version = "2.0.4"
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 Catalyst = "16"
 Pkg = "1.10"
 RuntimeGeneratedFunctions = "0.5"
 SafeTestsets = "0.1"
+SymbolicUtils = "4.46.4"
+Symbolics = "7.39.2"
 Test = "1.10"
 SciMLTesting = "2.10"
 julia = "1.10"

--- a/lib/JumpProblemLibrary/Project.toml
+++ b/lib/JumpProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "JumpProblemLibrary"
 uuid = "faf0f6d7-8cee-47cb-b27c-1eb80cef534e"
-version = "2.0.3"
+version = "2.0.4"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
## Summary
- JumpProblemLibrary x86 was resolving SymbolicUtils 4.46.1 / Symbolics 7.39.0 and failing hasha_seed precompile (`InexactError: trunc(UInt32, …)`).
- Depend directly on `SymbolicUtils ≥ 4.46.4` and `Symbolics ≥ 7.39.2` (bump sublib to 2.0.4).

## Test plan
- [ ] `Core (…, x86)` gets past SymbolicUtils/Symbolics precompile
- [ ] x64 Core still green

Made with [Cursor](https://cursor.com)